### PR TITLE
Set CLOEXEC on err pipe.

### DIFF
--- a/src/err_pipe.rs
+++ b/src/err_pipe.rs
@@ -56,6 +56,8 @@ impl ErrorWriter {
 impl ErrorPipe {
     pub fn new() -> Result<ErrorPipe> {
         let (read_fd, write_fd) = sys::pipe()?;
+        sys::set_cloexec(read_fd)?;
+        sys::set_cloexec(write_fd)?;
         Ok(ErrorPipe { read_fd, write_fd })
     }
 
@@ -118,8 +120,8 @@ impl ErrorPipe {
         // Close the read pipe.
         sys::close(read_fd).unwrap();
 
-        // Note that tokio-pipe sets CLOEXEC by default, so the write pipe will close
-        // automatically in the child process when it exec's.
+        // Since the pipe is CLOEXEC, so the write pipe will close automatically
+        // in the child process when it exec's.
         Ok(ErrorWriter { write_fd })
     }
 }


### PR DESCRIPTION
Not using tokio-pipe for this anymore, so we have to set CLOEXEC ourselves.

Resolves #32 