### PR TITLE
Feature/register proc ids server

### DIFF
--- a/python/procstar/agent/conn.py
+++ b/python/procstar/agent/conn.py
@@ -175,8 +175,19 @@ class Connection:
             # Connection closed.  Don't forget about it; it may reconnect.
             logger.warning(f"{self.info.socket}: connection closed")
             # FIXME: Think carefully the temporarily dropped connection logic.
+            raise WebSocketNotOpen(self.conn_id)
         else:
             self.info.stats.num_sent += 1
+
+
+    async def try_send(self, msg):
+        """
+        Sends a message, ignoring connection/not open errors.
+        """
+        try:
+            await self.send(msg)
+        except (NotConnectedError, WebSocketNotOpen):
+            pass
 
 
     def set_reconnect_timeout(self, duration, fn):

--- a/python/procstar/agent/exc.py
+++ b/python/procstar/agent/exc.py
@@ -47,3 +47,14 @@ class WebSocketNotOpen(RuntimeError):
 
 
 
+class ProcessUnknownError(RuntimeError):
+    """
+    The process is unknown to the remote agent.
+    """
+
+    def __init__(self, proc_id):
+        super().__init__(f"process unknown: {proc_id}")
+        self.proc_id = proc_id
+
+
+

--- a/python/procstar/agent/proc.py
+++ b/python/procstar/agent/proc.py
@@ -166,14 +166,14 @@ class Process:
         """
         Returns a coro that sends a request for updated result.
         """
-        return self.__conn.send(proto.ProcResultRequest(self.proc_id))
+        return self.__conn.try_send(proto.ProcResultRequest(self.proc_id))
 
 
     def request_fd_data(self, fd, *, interval=Interval(0, None)):
         """
         Returns a coro that requests updated output data,
         """
-        return self.__conn.send(proto.ProcFdDataRequest(
+        return self.__conn.try_send(proto.ProcFdDataRequest(
             proc_id =self.proc_id,
             fd      =fd,
             start   =interval.start,
@@ -294,7 +294,7 @@ class Processes(Mapping):
                     get_proc(proc_id)._on_message(msg)
 
             case proto.ConnectionTimeout():
-                logger.error(f"agent connection timeout: {conn_id}")
+                logger.warning(f"agent connection timeout: {conn_id}")
                 send_by_conn()
 
             case proto.ShutDown(shutdown_state):

--- a/python/procstar/agent/proc.py
+++ b/python/procstar/agent/proc.py
@@ -8,6 +8,7 @@ from   dataclasses import dataclass
 from   functools import cached_property
 import logging
 
+from   .exc import ProcessUnknownError
 from   procstar import proto
 from   procstar.lib.asyn import iter_queue
 from   procstar.lib.py import Interval
@@ -16,17 +17,6 @@ import procstar.lib.json
 logger = logging.getLogger(__name__)
 
 #-------------------------------------------------------------------------------
-
-class ProcessUnknownError(RuntimeError):
-    """
-    The process is unknown to the remote agent.
-    """
-
-    def __init__(self, proc_id):
-        super().__init__(f"process unknown: {proc_id}")
-        self.proc_id = proc_id
-
-
 
 class ProcessDeletedError(RuntimeError):
     """

--- a/python/procstar/agent/server.py
+++ b/python/procstar/agent/server.py
@@ -260,7 +260,6 @@ class Server:
             # we may add a timeout to do this.
             elif reconnect_timeout is not None:
                 def on_timeout(conn):
-                    logger.info(f"reconnect timeout: {conn_id}")
                     assert self.connections._pop(conn_id) is conn
                     # Let processes know that a connection timeout occurred.
                     self.processes.on_message(conn, proto.ConnectionTimeout())

--- a/python/procstar/proto.py
+++ b/python/procstar/proto.py
@@ -128,6 +128,7 @@ class ProcessInfo:
 class Register:
     conn: ConnectionInfo
     proc: ProcessInfo
+    proc_ids: List[str]
     access_token: str = ""
     shutdown_state: ShutdownState = ShutdownState.active
 
@@ -136,6 +137,8 @@ class Register:
         return cls(
             conn            =ConnectionInfo(**jso["conn"]),
             proc            =ProcessInfo(**jso["proc"]),
+            # Allow none for backward compatibility.  CLEANUP#38
+            proc_ids        =jso.get("proc_ids", None),
             access_token    =jso["access_token"],
             shutdown_state  =ShutdownState[jso["shutdown_state"]],
         )
@@ -149,6 +152,7 @@ class Register:
             proc            =self.proc,
             access_token    ="***",
             shutdown_state  =self.shutdown_state.name,
+            proc_ids        =self.proc_ids,
         )
 
 


### PR DESCRIPTION
Python side of #37 (plus other fixes).  Will not fix #37 until the Rust part is merged as well.  The Python component is backward-compatible.
